### PR TITLE
Fix Whitey's H2 border misplaced on PDF export.

### DIFF
--- a/themes/whitey.css
+++ b/themes/whitey.css
@@ -57,7 +57,7 @@ h3{
 }
 
 h2:after{
-	border-bottom: 1px solid #2f2f2f;
+    border-top: 1px solid #2f2f2f;
     content: '';
     width: 100px;
     display: block;


### PR DESCRIPTION
Whitey's H2 underline is painted some lines after its text,
overlaying another text if it coincides.

- Replace border-bottom by bottom-top on H2 properties definition.