### PR TITLE
correct font src URL's for Gothic theme

### DIFF
--- a/themes/gothic.css
+++ b/themes/gothic.css
@@ -4,28 +4,28 @@
 	font-family: 'TeXGyreAdventor';
 	font-style: normal;
 	font-weight: normal;
-	src: url(./gothic/texgyreadventor-regular.woff) format('woff');
+	src: url(./gothic/texgyreadventor-regular.otf);
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
 	font-family: 'TeXGyreAdventor';
 	font-style: normal;
 	font-weight: bold;
-	src: url(./gothic/texgyreadventor-bold.woff) format('woff');
+	src: url(./gothic/texgyreadventor-bold.otf) ;
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
 	font-family: 'TeXGyreAdventor';
 	font-style: italic;
 	font-weight: normal;
-	src: url(./gothic/texgyreadventor-italic.woff) format('woff');
+	src: url(./gothic/texgyreadventor-italic.otf);
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
 	font-family: 'TeXGyreAdventor';
 	font-style: italic;
 	font-weight: bold;
-	src: url(./gothic/texgyreadventor-bolditalic.woff) format('woff');
+	src: url(./gothic/texgyreadventor-bolditalic.otf);
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 


### PR DESCRIPTION
woff files are not present in repo. This patch uses the correct .otf extension. Cyrillic extension not addressed.